### PR TITLE
Makefile: don't fail on missing riscv-brs-spec.pdf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ build:
     $(HEADER_SOURCE)
 
 clean:
-	rm $(PDF_RESULT)
+	rm -f $(PDF_RESULT)


### PR DESCRIPTION
'make clean' should not fail if riscv-brs-spec.pdf does not exist.