### PR TITLE
UEFI: require EFI_TCG2_PROTOCOL if TPM v2 is present

### DIFF
--- a/brs.bib
+++ b/brs.bib
@@ -42,3 +42,7 @@
   title = {RISC-V Functional Fixed Hardware Specification},
   url = {https://github.com/riscv-non-isa/riscv-acpi-ffh}
 }
+@electronic{TcgEfiProt,
+  title = {TCG EFI Protocol Specification for TPM 2.0},
+  url = {https://trustedcomputinggroup.org/wp-content/uploads/EFI-Protocol-Specification-rev13-160330final.pdf},
+}

--- a/uefi.adoc
+++ b/uefi.adoc
@@ -23,4 +23,12 @@
 ==== Real-Time Clock (RTC)
 ==== UEFI Reset and Shutdown
 ==== Variable Services
+=== UEFI Protocols
+==== EFI TPM2 Protocol
+The EFI TPM2 Protocol (EFI_TCG2_PROTOCOL) let's an UEFI software communicate
+with a TPM v2 implementation.
+
+If a system provides a TPM v2, the firmware should implement the
+EFI TPM2 Protocol (EFI_TCG2_PROTOCOL) cite:[TcgEfiProt].
+
 === Firmware Update


### PR DESCRIPTION
The EFI_TCG2_PROTOCOL is needed to communicate with a TPM v2.