### PR TITLE
Add a UEFI-PI reference to the bib file.

### DIFF
--- a/brs.bib
+++ b/brs.bib
@@ -10,6 +10,10 @@
   title = {Unified Extensible Firmware Interface Specification 2.11},
   url = {https://uefi.org/specifications}
 }
+@electronic{UEFI-PI,
+  title = {UEFI Platform Initialization Specification 1.9},
+  url = {https://uefi.org/specifications}
+}
 @electronic{SMBIOS,
   title = {System Management BIOS},
   url = {https://www.dmtf.org/standards/smbios}


### PR DESCRIPTION
Reference a yet-non-existing 1.9 version of the spec.