### PR TITLE
Partially resolve https://github.com/riscv-non-isa/riscv-brs/issues/52

### DIFF
--- a/sbi.adoc
+++ b/sbi.adoc
@@ -17,9 +17,9 @@ following optional extensions are mandatory for a compliant system.
 * SBI Hart State Management (HSM)
 
 * SBI System Reset (SRST)
+** See <<uefi-resetsystem>> for additional notes on SRST use by a UEFI implementation and by an OS.
+
 * SBI System Suspend (SUSP)
-** The supervisor operating system should preferably use UEFI interfaces for system
-   reset/suspend instead of invoking System Reset/Suspend SBI extensions directly.
 
 * SBI Performance Monitoring (PMU)
 

--- a/uefi.adoc
+++ b/uefi.adoc
@@ -33,7 +33,33 @@ validated against the UEFI security database.]
 ==== Runtime Exception Level
 ==== Runtime Memory Map
 ==== Real-Time Clock (RTC)
+
+[[uefi-resetsystem]]
 ==== UEFI Reset and Shutdown
+
+The UEFI ResetSystem() runtime service must be implemented using the SBI System Reset (SRST) extension. The following table maps the UEFI RT and SRST call parameters:
+
+[%autowidth]
+|===
+|ResetSystem() ResetType|sbi_system_reset type
+
+|EfiResetShutdown
+|0x00000000 (Shutdown)
+
+|EfiResetCold
+|0x00000001 (Cold reboot)
+
+|EfiResetWarm
+|0x00000002 (Warm reboot)
+
+|EfiResetPlatformSpecific
+|0xF0000000 - 0xFFFFFFFF (Vendor or platform specific reset type)
+|===
+
+The OS must call the ResetSystem() runtime service call to reset the system,
+preferring this to SBI SRST or other platform-specific mechanisms. This
+allows for UEFI implementations to perform any required platform tasks on the way out (e.g. servicing UpdateCapsule() or persisting non-volatile variables in some implementations).
+
 ==== Variable Services
 === UEFI Protocols
 ==== EFI TPM2 Protocol


### PR DESCRIPTION
SUSP has no UEFI RT equivalent, so it doesn't make sense to guide readers to prefer a UEFI interface here.

Make it a requirement (not a preference or suggestions) that OSes use the UEFI RT system reset call over SBI SRST.