### PR TITLE
Remove SUSP as a requirement.

### DIFF
--- a/sbi.adoc
+++ b/sbi.adoc
@@ -19,8 +19,6 @@ following optional extensions are mandatory for a compliant system.
 * SBI System Reset (SRST)
 ** See <<uefi-resetsystem>> for additional notes on SRST use by a UEFI implementation and by an OS.
 
-* SBI System Suspend (SUSP)
-
 * SBI Performance Monitoring (PMU)
 
 In addition to this, the following SBI extensions are only mandatory if required


### PR DESCRIPTION
Closes off https://github.com/riscv-non-isa/riscv-brs/issues/52, as it was agreed suspending-to-RAM is not a universal requirement (it could be a requirement for a a specific platform, and even then could hypothetically be wrapped via an ACPI requirement... this is still TBD to be figured out)