### PR TITLE
Add a new recipe to support non-UEFI firmware (coreboot).

### DIFF
--- a/about.adoc
+++ b/about.adoc
@@ -10,6 +10,7 @@
 | BRS             | RISC-V Boot and Runtime Services. This document.
 | BRS-I           | Boot and Runtime Services Recipe targeting interoperation across different software suppliers.
 | BRS-B           | Boot and Runtime Services Recipe using a bespoke solution.
+| BRS-M           | Boot and Runtime Services Recipe using a minimal solution.
 | DT              | DeviceTree cite:[DT].
 | EBBR            | Embedded Base Boot Requirements Specification cite:[EBBR].
 | OSV             | Operating System Vendor.

--- a/intro.adoc
+++ b/intro.adoc
@@ -11,7 +11,7 @@ It is expected that the Boot and Runtime Services specification will periodicall
 
 === Approach to Solutions
 
-The Boot and Runtime Services specification focuses on two solutions in the form of what is deemed a recipe. Each recipe contains the requirements needed to fulfill each solution. The requirements of each recipe will be marked accordingly with an unique identifier. The recipe names are named BRS-I and BRS-B, Interoperable and Bespoke, respectively.
+The Boot and Runtime Services specification focuses on three solutions in the form of what is deemed a recipe. Each recipe contains the requirements needed to fulfill each solution. The requirements of each recipe will be marked accordingly with an unique identifier. The recipe names are named BRS-I, BRS-B and BRS-M, Interoperable and Bespoke, respectively.
 
 === Testing and Conformance
 

--- a/non-normative/acpi.adoc
+++ b/non-normative/acpi.adoc
@@ -1,7 +1,8 @@
 ACPI information is structured as tables with the address of the root of these
 tables known as Root System Description Table (RSDP) passed to the OS
-via a EFI_ACPI_20_TABLE_GUID configuration table in the UEFI firmware.
-The Operating System uses this address to locate all other ACPI tables.
+via a EFI_ACPI_20_TABLE_GUID configuration table in the UEFI firmware. In
+addition, RSDP can be obtained in other ways, such as DT. The Operating System
+uses this address to locate all other ACPI tables.
 
 Certain implementations may make use of the RISC-V Functional Fixed hardware Specification cite:[FFH].
 

--- a/non-normative/recipes.adoc
+++ b/non-normative/recipes.adoc
@@ -30,3 +30,18 @@ configuration utilities. The actual meaning of the default (compatible to
 BRS-I) configuration would be highly specific to the vendor. In this example,
 it could capping all harts at the same performance level, or it could mean
 disabling efficiency harts.
+
+[[recipe-brs-m-guidance]]
+===== BRS-M Recipe Guidance
+
+In contrast to BRS-I and BRS-B, BRS-M has no implementation of UEFI related
+services. Non-UEFI firmware, such as *coreboot*, can also supports boot well.
+Although non-UEFI firmware does not support UEFI interface, it can also
+provide ACPI, SMBIOS and SBI services. ACPI and SMBIOS can be passed through
+DT.
+
+The introduction of coreboot can refer to https://www.coreboot.org/[coreboot].
+This solution is the startup mode for coreboot plus payload. coreboot does the
+basic and necessary hardware initialization, where ACPI and SMBIOS tables are
+created, and then loads and executes payload, which completes the boot and
+additional functions. linuxboot is a common payload.

--- a/recipes.adoc
+++ b/recipes.adoc
@@ -6,8 +6,8 @@ requirements that hardware, firmware, and software providers can
 implement to increase the likelihood that software written to the
 recipe will run predictably on all conforming devices.
 
-The BRS specification defines two recipes: BRS-I (for "Interoperable")
-and BRS-B (for "Bespoke").
+The BRS specification defines three recipes: BRS-I (for "Interoperable"),
+BRS-B (for "Bespoke") and BRS-M (for "Minimal").
 
 === BRS-I Recipe
 
@@ -65,4 +65,21 @@ custom distributions.
 |===
 | Profile | UEFI | ACPI | DT | SBI | SMBIOS
 | >= RVA20 | EBBR cite:[EBBR] | optional, >= 6.6 | optional, >= v0.3 | >= 2.0 | optional, >= 3.6.0
+|===
+
+=== BRS-M Recipe
+
+BRS-M is used for cases that do not require UEFI. BRS-M is the
+smallest recipe. This recipe does not require UEFI boot and runtime
+service implementations. In some boot scenarios, non-UEFI firmware
+can also support boot, they only focus on the boot process and support
+the necessary interaction interfaces.
+<<recipe-brs-m-guidance, See additional guidance>>.
+
+.BRS-M Recipe Overview
+[width=100%]
+[%header, cols="10,20,20,10,20"]
+|===
+| Profile | ACPI | DT | SBI | SMBIOS
+| >= RVA20 | optional, >= 6.6 | optional, >= v0.3 | >= 2.0 | optional, >= 3.6.0
 |===


### PR DESCRIPTION
We want to add a new recipe to support non-UEFI firmware (coreboot), and this recipe doesn't affect the previous recipes.