### PR TITLE
uefi: remove redundant address translation requirements

### DIFF
--- a/uefi.adoc
+++ b/uefi.adoc
@@ -12,8 +12,6 @@ A compliant system must:
 * Meet the following UEFI memory map requirements:
 ** The default memory space attribute must be EFI_MEMORY_WB.
 ** Enable address translation.
-*** Any memory space defined by the UEFI memory map must be identity mapped (virtual address equals physical address), although the attributes of certain regions may not have all read, write and execute attributes or be unmarked for purposes of platform protection.
-*** The mappings to other regions are undefined and may vary from implementation to implementation.
 * Declare a EFI_CONFORMANCE_PROFILES_UEFI_SPEC_GUID conformance profile, as the BRS requirements are a superset of UEFI cite:[UEFI] (Section 2.6).
 * Declare EFI_CONFORMANCE_PROFILE_BRS_1_0_SPEC_GUID conformance profile ({ 0x05453310, 0x0545, 0x0545, { 0x05, 0x45, 0x33, 0x05, 0x45, 0x33, 0x05, 0x45 }}).
 


### PR DESCRIPTION
Now that https://mantis.uefi.org/mantis/view.php?id=2376 is approved for 2.10 errata, the BRS spec no longer has to explain how the mappings ought to be done.