### PR TITLE
Add WIP ISA extension details that can void the requirement of SBI PMU.

### DIFF
--- a/sbi.adoc
+++ b/sbi.adoc
@@ -21,8 +21,6 @@ following optional extensions are mandatory for a compliant system.
 * SBI System Reset (SRST)
 ** See <<uefi-resetsystem>> for additional notes on SRST use by a UEFI implementation and by an OS.
 
-* SBI Performance Monitoring (PMU)
-
 In addition to this, the following SBI extensions are only mandatory if required
 ISA extension is not available in the platform. 
 
@@ -34,4 +32,10 @@ ISA extension is not available in the platform.
 * SBI RFENCE 
 ** This extension is mandatory only if the platform doesn't implement
    Incoming MSI Controller (IMSIC).
+* SBI Performance Monitoring (PMU)
+** This extension is mandatory only if the counter delegation related extensions
+(S*csrind, Smcdeleg, Ssccfg) are not present.
+
+NOTE: The above extension are currently being developed by the performance
+analsys TG.
 


### PR DESCRIPTION
There were some discussions about referring Server SoC specification here as it defines particular ID (RVA_020) for a set of ISA extensions. 
The current soc spec version says 
"Ssccfg, Sscind, and Ssctr are under construction."

As these extensions are not in the final list, I was not sure if we should include those at this point. It also mandates Sdtring. The SBI debug extension is under development and will be ratified in 2024 as a part of SBI v3.0.