### PR TITLE
sbi: require >= v2.0 in all parts of the document

### DIFF
--- a/sbi.adoc
+++ b/sbi.adoc
@@ -10,7 +10,7 @@ privilege mode in order to be compatible with this specification.
 [%header, cols="5,25"]
 |===
 | ID#     ^| Requirement
-| SBI_010  | The SBI implementation MUST conform to SBI v1.0.
+| SBI_010  | The SBI implementation MUST conform to SBI v2.0 or later.
 | SBI_020  | The SBI implementation MUST implement the Hart State Management (HSM) extension.
 2+| _HSM is used by an OS for starting up, stopping, suspending and querying the status of secondary harts.
 | SBI_030  | The System Reset (SRST) extension MUST be implemented.


### PR DESCRIPTION
In chapter 2.2 BRS-B recipe we require SBI >= 2.0. In chapter 4 SBI requirements be require SBI == 1.0. Remove the contradiction.

Closes: #105