### PR TITLE
Brs b no pci required

### DIFF
--- a/uefi.adoc
+++ b/uefi.adoc
@@ -45,7 +45,7 @@ See additional <<uefi-rt, requirements under UEFI Runtime Services>>.
 [%header, cols="5,25"]
 |===
 | ID#     ^| Requirement
-| UIO_010 | Systems implementing PCIe MUST always initialize all root complex hardware and perform resource assignment for all endpoints and usable hotplug-capable switches in the system, even in a boot scenario from a non-PCIe boot device.
+| UIO_010 | BRS-I Systems implementing PCIe MUST always initialize all root complex hardware and perform resource assignment for all endpoints and usable hotplug-capable switches in the system, even in a boot scenario from a non-PCIe boot device. For BRS-B systems, this implementation is optional.
 2+| _This is a stronger requirement than the PCI Firmware Specification firmware/OS device hand-off state (cite:[PCIFW] Section 3.5). <<uefi-guidance-pcie, See additional guidance>>._
 | UIO_020 | Systems implementing EFI_GRAPHICS_OUTPUT_PROTOCOL SHOULD configure the frame buffer to be directly accessible.
 2+| _That is, EFI_GRAPHICS_PIXEL_FORMAT is not PixelBltOnly and FrameBufferBase is reported as a valid hart MMIO address._


### PR DESCRIPTION
End-users have had trouble over the years with requiring BIOS to
configure PCIe. On the System 76 laptop with 4 thunderbolt
ports, it was an issue; and, on hyperscalar server platforms,
there have been cases where it is best to let linux configure
pcie, as firmware does not optimize to suit the case. The
system-76 case was a case also seen years ago on HPC nodes: BIOS
was required to configure the system for maximum generality,
making certain hardware impossible to use (4th thunderbolt port
on system 76; Quadrics NICs on HPC); in each case, the fix was
to get the BIOS to do minimal PCI configuration. Coreboot has a
build time option to enable this minimal PCI configuration,
deveoped jointly by Google and Intel.