### PR TITLE
Fix https://github.com/riscv-non-isa/riscv-brs/issues/128

### DIFF
--- a/acpi.adoc
+++ b/acpi.adoc
@@ -1,9 +1,15 @@
 [[acpi]]
-== ACPI Requirements
+== BRS-I ACPI Requirements
 
 The Advanced Configuration and Power Interface specification provides the OS-centric view of system configuration, various hardware resources, events and power management.
 
-This section defines the BRS-I mandatory and optional ACPI requirements on top of cite:[ACPI] and cite:[UEFI]. Additional non-normative guidance may be found in the <<acpi-guidance, Firmware Implementation Guidance>> section.
+This section defines the BRS-I mandatory and optional ACPI
+requirements on top of existing cite:[ACPI] and cite:[UEFI]
+specification requirements. Additional non-normative guidance may be
+found in the <<acpi-guidance, Firmware Implementation Guidance>>
+section.
+
+IMPORTANT: All content in this section is optional and recommended for BRS-B.
 
 [width=100%]
 [%header, cols="5,25"]
@@ -36,13 +42,12 @@ available to an OS loader via the standard UEFI EFI_GRAPHICS_OUTPUT_PROTOCOL int
 |===
 
 [[acpi-aml]]
-=== ACPI Methods and Objects
+=== BRS-I ACPI Methods and Objects
 
 This section lists additional requirements for ACPI methods and
 objects.
 
 <<acpi-guidance-aml, See additional guidance>>.
-
 
 [width=100%]
 [%header, cols="5,25"]

--- a/smbios.adoc
+++ b/smbios.adoc
@@ -1,10 +1,14 @@
 [[smbios]]
-== SMBIOS Requirements
+== BRS-I SMBIOS Requirements
 
 The System Management BIOS (SMBIOS) specification defines a standard format for presenting management information about an implentation, mostly focusing on hardware components.
 
 This section defines the BRS-I mandatory and optional SMBIOS requirements
-on top of cite:[SMBIOS], and is optional and recommended for BRS-B. Additional non-normative guidance may be found in the <<smbios-guidance, Firmware Implementation Guidance>> section.
+on top of existing cite:[SMBIOS] specification requirements. Additional
+non-normative guidance may be found in the <<smbios-guidance, Firmware
+Implementation Guidance>> section.
+
+IMPORTANT: All content in this section is optional and recommended for BRS-B.
 
 [width=100%]
 [%header, cols="5,25"]

--- a/uefi.adoc
+++ b/uefi.adoc
@@ -1,9 +1,14 @@
 [[uefi]]
-== UEFI Requirements
+== BRS-I UEFI Requirements
 
 The Unified Extensible Firmware Interface (UEFI) specification describes the interface between the OS and the supervisor-mode firmware.
 
-This section defines the BRS-I mandatory and optional UEFI requirements on top of cite:[UEFI], and is optional and recommended for BRS-B. Additional non-normative guidance may be found in the <<uefi-guidance, Firmware Implementation Guidance>> section.
+This section defines the BRS-I mandatory and optional UEFI
+requirements on top of existing cite:[UEFI] specification
+requirements. Additional non-normative guidance may be found in the
+<<uefi-guidance, Firmware Implementation Guidance>> section.
+
+IMPORTANT: All content in this section is optional and recommended for BRS-B.
 
 [width=100%]
 [%header, cols="5,25"]
@@ -15,7 +20,7 @@ This section defines the BRS-I mandatory and optional UEFI requirements on top o
 
               * The default memory space attribute must be EFI_MEMORY_WB.
               * Enable address translation.
-	      * Only use EfiRuntimeServicesData memory type for describing any SMBIOS data structures.
+              * Only use EfiRuntimeServicesData memory type for describing any SMBIOS data structures.
 | UEFI_040 | An implemenation MAY comply with the UEFI Platform Initialization Specification cite:[UEFI-PI].
 | UEFI_050 | All hart manipulation internal to a firmware implementation SHOULD be done before completion of the EFI_EVENT_GROUP_READY_TO_BOOT event, with all secondary harts remaining offline from that point on.
 2+| _This ensures an OS loader is entered with an OS-compatible state for all harts._
@@ -25,7 +30,7 @@ This section defines the BRS-I mandatory and optional UEFI requirements on top o
 2+| _Only a system fully compliant to the requirements in this section may declare the EFI_CONFORMANCE_PROFILE_BRS_1_0_SPEC_GUID conformance profile._
 |===
 
-=== Security Requirements
+=== BRS-I Security Requirements
 
 [width=100%]
 [%header, cols="5,25"]
@@ -39,7 +44,7 @@ EFI Protocol Specification cite:[TcgEfiPlat].
 
 See additional <<uefi-rt, requirements under UEFI Runtime Services>>.
 
-=== I/O-specific Requirements
+=== BRS-I I/O-specific Requirements
 
 [width=100%]
 [%header, cols="5,25"]
@@ -52,7 +57,7 @@ See additional <<uefi-rt, requirements under UEFI Runtime Services>>.
 |===
 
 [[uefi-rt]]
-=== UEFI Runtime Services
+=== BRS-I UEFI Runtime Services
 
 [width=100%]
 [%header, cols="5,25"]
@@ -88,7 +93,7 @@ See additional <<uefi-rt, requirements under UEFI Runtime Services>>.
 	     * The 'dbx' signature database variable EFI_IMAGE_SECURITY_DATABASE1 must be created with EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS, to prevent rollback.
 |===
 
-=== Firmware Update
+=== BRS-I Firmware Update
 
 [width=100%]
 [%header, cols="5,25"]


### PR DESCRIPTION
I don't see a way to make a footnote on every page, so instead add a highly-visible admonition to uefi, acpi and smbios sections, and name the sections and subsections to include BRS-I.

Feel free to propose a better mechanism.