### PR TITLE
Resolve https://github.com/riscv-non-isa/riscv-brs/issues/118

### DIFF
--- a/sbi.adoc
+++ b/sbi.adoc
@@ -12,9 +12,7 @@ privilege mode in order to be compatible with this specification.
 | ID#     ^| Requirement
 | SBI_010  | The SBI implementation MUST conform to SBI v2.0 or later.
 | SBI_020  | The SBI implementation MUST implement the Hart State Management (HSM) extension.
-2+| _HSM is used by an OS for starting up, stopping, suspending and querying the status of secondary harts.
-| SBI_030  | The System Reset (SRST) extension MUST be implemented.
-2+| _See <<uefi-resetsystem, UEFI requirements>> for additional notes on SRST use by a UEFI and OS._
+2+| _HSM is used by an OS for starting up, stopping, suspending and querying the status of secondary harts._
 |===
 
 Certain requirements are conditional on the presence of RISC-V ISA extensions or system features.
@@ -23,9 +21,9 @@ Certain requirements are conditional on the presence of RISC-V ISA extensions or
 [%header, cols="5,25"]
 |===
 | ID#     ^| Requirement
-| SBI_040  | The Timer (TIME) extension MUST be implemented, if the RISC-V "stimecmp / vstimecmp" Extension (Sstc) cite: [Sstc] is not available.
-| SBI_050  | The S-Mode IPI (IPI) extension MUST be implemented, if the Incoming MSI Controller (IMSIC) cite: [Aia] is not available.
-| SBI_060  | The RFENCE (RFNC) extension MUST be implemented, if the Incoming MSI Controller (IMSIC) cite: [Aia] is not available.
-| SBI_070  | The Performance Monitoring (PMU) extension MUST be implemented, if the counter delegation-related ISA extensions (S*csrind cite: [Sscsrind], Smcdeleg cite: [Smcdeleg], Ssccfg cite: [Smcdeleg]) are not present.
+| SBI_030  | The Timer (TIME) extension MUST be implemented, if the RISC-V "stimecmp / vstimecmp" Extension (Sstc) cite: [Sstc] is not available.
+| SBI_040  | The S-Mode IPI (IPI) extension MUST be implemented, if the Incoming MSI Controller (IMSIC) cite: [Aia] is not available.
+| SBI_050  | The RFENCE (RFNC) extension MUST be implemented, if the Incoming MSI Controller (IMSIC) cite: [Aia] is not available.
+| SBI_060  | The Performance Monitoring (PMU) extension MUST be implemented, if the counter delegation-related ISA extensions (S*csrind cite: [Sscsrind], Smcdeleg cite: [Smcdeleg], Ssccfg cite: [Smcdeleg]) are not present.
 2+| _NOTE: The PMU extension is currently being developed by the performance analysis TG cite: [PerfAnalysis]._
 |===

--- a/uefi.adoc
+++ b/uefi.adoc
@@ -72,17 +72,8 @@ See additional <<uefi-rt, requirements under UEFI Runtime Services>>.
              * GetTime and SetTime must return EFI_UNSUPPORTED, when called after the UEFI boot services have been exited.
              * GetTime and SetTime must be appropriately described in EFI_RT_PROPERTIES_TABLE.
 2+|_Also see <<acpi-tad, AML_070>>_.
-| [[uefi-resetsystem]] URT_030 a| The UEFI ResetSystem() runtime service MUST be implemented using the SBI SRST extension. The following table maps the UEFI RT and SRST call parameters:
-[width=100%]
-[%header]
-!===
-!ResetSystem() ResetType ^! sbi_system_reset type
-!EfiResetShutdown ! 0x00000000 (Shutdown)
-!EfiResetCold ! 0x00000001 (Cold reboot)
-!EfiResetWarm ! 0x00000002 (Warm reboot)
-!EfiResetPlatformSpecific ! 0xF0000000 - 0xFFFFFFFF (Vendor or system-specific reset type)
-!===
-2+| _The OS MUST call the ResetSystem() runtime service call to reset or shutdown the system, preferring this to SBI SRST, ACPI or other system-specific mechanisms. This allows for systems to perform any required system tasks on the way out (e.g. servicing UpdateCapsule() or persisting non-volatile variables in some systems)._
+| URT_030 a| The UEFI ResetSystem() runtime service MUST be implemented.
+2+| _The OS MUST call the ResetSystem() runtime service call to reset or shutdown the system, preferring this to SBI, ACPI or other system-specific mechanisms. This allows for systems to perform any required system tasks on the way out (e.g. servicing UpdateCapsule() or persisting non-volatile variables in some systems)._
 | URT_040 | Non-volatile UEFI variables MUST persist across calls to the Reset System() runtime service call.
 | URT_050 | UEFI Runtime Services MUST be able to update the variables directly without the aid of an OS.
 | URT_060 a| The following requirements MUST be met for systems with UEFI Secure Boot:


### PR DESCRIPTION
We can remove the SRST requirement. It doesn't matter how SystemReset is implemented, we're only concerned with it being the only mechanism used by a BRS-I OS.

What about BRS-B? Well it can choose to do whatever, which (most likely) will mean using SRST. A particular BRS-B implementation may impose any number of additional requirements not actually present in the BRS spec.

If we can do this for SRST, why can't we do this for HSM? Because the SBI requirements are effectively the common requirements for BRS-B and BRS-I, and we don't /have/ (or want) another mechanism for hart manipulation.