### PR TITLE
ACPI: Add requirement to have PLIC/APLIC namespace devices

### DIFF
--- a/acpi-id.adoc
+++ b/acpi-id.adoc
@@ -1,0 +1,30 @@
+[[acpi-ids]]
+=== RVI specific ACPI IDs
+
+ACPI ID is used in the _HID (Hardware ID), _CID (Compatibility ID) or
+_SUB (Subsystem ID) objects as described in the ACPI Specification for
+devices that do not have a standard enumeration mechanism. The ACPI ID
+consists of two parts: a Vendor ID followed by a product identifier.
+
+Vendor IDs consist of 4 characters, each character being either an
+uppercase letter (A-Z) or a numeral (0-9). The Vendor ID should be
+unique across the Industry and registered by the UEFI forum. For RVI
+standard devices, **"RSCV"** is the Vendor ID registered. Vendor-specific
+devices can use an appropriate Vendor ID registered for the manufacturer.
+
+Product Identifiers are always four-character hexadecimal numbers (0-9
+and A-F). The Device Manufacturer is responsible for assigning this
+identifier to each product model.
+
+This document contains the canonical list of ACPI IDs for the namespace
+devices that adhere to the RVI specifications. The RVI task groups may
+make pull requests against this repository to request the allocation of
+ACPI ID for any new device.
+
+[width=100%]
+[%header, cols="5,25"]
+|===
+| ACPI ID     ^| Device
+| RSCV0001     | RISC-V Platform-Level Interrupt Controller (PLIC)
+| RSCV0002     | RISC-V Advanced Platform-Level Interrupt Controller (APLIC)
+|===

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -35,6 +35,11 @@ available to an OS loader via the standard UEFI EFI_GRAPHICS_OUTPUT_PROTOCOL int
  ** Use Interface Type 0x12 (16550-compatible with parameters defined in Generic Address Structure).
  ** There must be a matching AML device object.
 2+| _<<acpi-guidance-spcr, See additional guidance>>_.
+| [[acpi-namespace-dev]]ACPI_080 | Depending on the interrupt controller
+implemented by the system, PLIC or APLIC namespace devices must be
+present in the ACPI namespace along with MADT entries. <<acpi-ids,
+See RVI ACPI IDs>>.
+2+| _Also see <<acpi-irq-gsb, AML_090>> and <<acpi-irq-dep, AML_100>>_.
 |===
 
 [[acpi-aml]]
@@ -69,4 +74,14 @@ vendor-specific OS driver for correct function (SPI, I2C, etc), the TAD must
 be functional if the OS driver is not loaded. That is, when a dependent
 driver is loaded, an AML method switches further accesses to go
 through the driver-backed OperationRegion._
+| [[acpi-irq-gsb]] AML_090 | PLIC and APLIC devices must support
+Global System Interrupt Base (_GSB, cite:[ACPI] Section 6.2.7).
+<<acpi-guidance-gsi-namespace, See additional guidance>>.
+| [[acpi-irq-dep]] AML_100 | Devices which use Global System
+Interrupts (GSI) must indicate the dependency on corresponding
+interrupt controller using Operation Region Dependencies (_DEP,
+cite:[ACPI] Section 6.5.8).
+<<acpi-guidance-gsi-namespace, See additional guidance>>.
 |===
+
+include::acpi-id.adoc[]

--- a/non-normative/acpi.adoc
+++ b/non-normative/acpi.adoc
@@ -104,6 +104,41 @@ not be decoded in a system-specific manner to divine CPU topology.
 The PPTT Processor Properties Topology Table (PPTT) is to be used to
 describe affinities.
 
+[[acpi-guidance-gsi-namespace]]
+==== PLIC/APLIC as namespace devices
+The devices which have wired interrupts (GSI), should provide the
+dependency on the appropriate interrupt controller similar to below
+example with PLIC.
+
+
+ Scope (\_SB)
+ {
+    Device (IC00)
+    {
+        Name (_HID, "RSCV0001") // _HID: Hardware ID
+        Name (_UID, Zero)  // _UID: Unique ID
+        Method(_GSB) {
+            Return (0x10) // Global System Interrupt Base for this PLIC starts at 16
+       }
+    }
+    Device (DEV1)
+    { 
+      ...
+      Name (_DEP, Package() {\_SB.IC00})
+      Name (_CRS, ResourceTemplate ()  // _CRS: Current Resource Settings
+      {   
+          Memory32Fixed (ReadWrite,
+            0x10010000,         // Address Base.
+            0x00010000,         // Address Length
+            )
+          Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive, ,,)
+          { 
+            0x10,
+          }
+      })
+    }
+ }
+
 [[acpi-guidance-pcie]]
 ==== PCIe
 


### PR DESCRIPTION
PLIC and APLIC need to be namespace devices as well so that devices can add dependencies using _DEP. This is required for the OS to ensure drivers are probed in proper order.

So, this commit
1) Creates a new section under ACPI to list of ACPI IDs maintained for RVI standard devices.
2) Adds new requirement to mandate namespace devices for PLIC and APLIC. 3) Mandates _GSB required to map the namespace device to MADT. 4) Mandates _DEP to indicate dependency between devices and interrupt controller for GSI interrupts.

This is discussed in PRS meeting on 04/11/2024. This should close https://github.com/riscv-non-isa/riscv-brs/issues/127

PoC available at:
https://github.com/vlsunil/qemu/tree/riscv_acpi_dep_v1
https://github.com/vlsunil/linux/tree/acpi_b2_v4_dep_v1
