### PR TITLE
Remove incorrect definition of 'system'

### DIFF
--- a/intro.adoc
+++ b/intro.adoc
@@ -63,6 +63,5 @@ Most terminology has the standard RISC-V meaning. This table captures other term
 | SBI             | _RISC-V Supervisor Binary Interface Specification_ cite:[SBI].
 | SMBIOS          | _System Management BIOS (SMBIOS) Reference Specification_ cite:[SMBIOS].
 | SoC             | System on a chip, a combination of processor and supporting chipset logic in single package.
-| System          | A system is the entirety of a computing entity, including all hardware, firmware and software (hypervisor, operating system, user applications, user data). A system can be thought of both as a logical construct (e.g. a software stack) or physical construct (e.g. a notebook, a desktop, a server, a network switch, etc).
 | UEFI            | _Unified Extensible Firmware Interface Specification_ cite:[UEFI].
 |===


### PR DESCRIPTION
Remove the overly prescriptive definition of the word system from the glossary.  The word 'system' is used throughout the document with various differing meanings.  In addition to being inconsistent with each other, the various meanings do not follow the definition in the glossary.

Addresses issue #125 