### PR TITLE
smbios: cleaning up smbios requirements

### DIFF
--- a/non-normative/smbios.adoc
+++ b/non-normative/smbios.adoc
@@ -1,4 +1,4 @@
-Note the DMTF requirements on the 64-bit SMBIOS 3.0 entry point (cite:[SMBIOS] Section 5.2.2) and data structures (cite:[SMBIOS] Section 6.2).
+Note the DMTF requirements on the 64-bit SMBIOS 3.0 entry point (cite:[SMBIOS] Section 5.2.2), and the conformance guidelines (cite:[SMBIOS] Annex A).
 
 ==== Type 44 Processor-Specific Data
 

--- a/smbios.adoc
+++ b/smbios.adoc
@@ -17,23 +17,21 @@ NOTE: The structures and fields in this section are defined in a manner consiste
 |===
 | ID#     ^| Requirement
 | `SMBIOS_010` | A Baseboard/Module Information (Type 02) structure SHOULD be implemented.
-| `SMBIOS_020` | A System Enclosure/Chassis (Type 03) structure SHOULD be implemented.
 2+|_This relaxes the SMBIOS specification requirement._
-| `SMBIOS_030` | A Processor Information (Type 04) structure, meeting the additional <<smbios-type04>> clarifications, MUST be implemented.
+| `SMBIOS_020` | A Processor Information (Type 04) structure, meeting the additional <<smbios-type04>> clarifications, MUST be implemented.
 2+|_This supersedes the RISC-V specific language in the SMBIOS specification (cite:[SMBIOS], Section 7.5.3.5)._
-| `SMBIOS_040` | A Port Connector Information (Type 08) SHOULD be implemented.
-| `SMBIOS_050` | A System Slots (Type 09) structure MUST be implemented, when expansion slots are present.
-| `SMBIOS_060` | An OEM Strings (Type 11) structure SHOULD be implemented.
-| `SMBIOS_070` | A BIOS Language Information (Type 13) structure SHOULD be implemented.
-| `SMBIOS_080` | A Group Associations (Type 14) structure SHOULD be implemented.
-| `SMBIOS_090` | An IPMI Device Information (Type 38) structure MUST be implemented, when an IPMIv1.0 host interface is present.
-| `SMBIOS_100` | A System Power Supplies (Type 39) structure SHOULD be implemented.
-| `SMBIOS_110` | An Onboard Devices Extended Information (Type 41) structure SHOULD be implemented.
-| `SMBIOS_120` | A Redfish Host Interface (Type 42) structure MUST be implmented, when a Redfish host interface is present.
-| `SMBIOS_130` | A TPM Device (Type 43) structure MUST be implmented, when a TPM is present.
-| `SMBIOS_140` | A Processor Additional Information (Type 44) structure MUST be implemented.
+| `SMBIOS_030` | A Port Connector Information (Type 08) SHOULD be implemented.
+| `SMBIOS_040` | An OEM Strings (Type 11) structure SHOULD be implemented.
+| `SMBIOS_050` | A BIOS Language Information (Type 13) structure SHOULD be implemented.
+| `SMBIOS_060` | A Group Associations (Type 14) structure SHOULD be implemented.
+| `SMBIOS_070` | An IPMI Device Information (Type 38) structure MUST be implemented, when an IPMIv1.0 host interface is present.
+| `SMBIOS_080` | A System Power Supplies (Type 39) structure SHOULD be implemented.
+| `SMBIOS_090` | An Onboard Devices Extended Information (Type 41) structure SHOULD be implemented.
+| `SMBIOS_100` | A Redfish Host Interface (Type 42) structure MUST be implmented, when a Redfish host interface is present.
+| `SMBIOS_110` | A TPM Device (Type 43) structure MUST be implmented, when a TPM is present.
+| `SMBIOS_120` | A Processor Additional Information (Type 44) structure MUST be implemented.
 2+| _See the <<smbios-type44, structure definitions below>>_.
-| `SMBIOS_150` | A Firmware Inventory Information (Type 45) structure SHOULD be implemented.
+| `SMBIOS_130` | A Firmware Inventory Information (Type 45) structure SHOULD be implemented.
 |===
 
 [[smbios-type04]]


### PR DESCRIPTION
Cleaning up SMBIOS requirements by removing duplicates found in the current specification and instead referencing the corresponding requirements outlined in the DMTF SMBIOS Specification.