### PR TITLE
acpi-id: Reserve ACPI ID for IOMMU

### DIFF
--- a/acpi-id.adoc
+++ b/acpi-id.adoc
@@ -28,5 +28,6 @@ ACPI ID for any new device.
 | `RSCV0001`     | RISC-V Platform-Level Interrupt Controller (PLIC)
 | `RSCV0002`     | RISC-V Advanced Platform-Level Interrupt Controller (APLIC)
 | `RSCV0003`     | NS16650 UART compatible with an SPCR definition using `Interface Type` 0x12
+| `RSCV0004`     | RISC-V IOMMU implemented as a platform device
 2+| _Also see <<acpi-props-uart>>._
 |===


### PR DESCRIPTION
RISC-V IOMMU can be implemented as a PCI device or a platform device. When it is a platform device, it can have dependency on PLIC/ACPI  due to wired interrupts it may need. So, reserve the ACPI ID to support this use case.