### PR TITLE
non-normative/acpi.adoc: Add RIMT as additional table

### DIFF
--- a/non-normative/acpi.adoc
+++ b/non-normative/acpi.adoc
@@ -65,6 +65,7 @@ information about certain capabilities like ISA string, cache and MMU info.
 |Error Injection Table (EINJ)                  |18.6.1        |If APEI is supported
 |Error Record Serialization Table (ERST)       |18.5          |If APEI is supported
 |Hardware Error Source Table (HEST)            |18.3.2        |If APEI is supported
+|RISC-V IO Mapping Table (RIMT)                |New           |If the system supports IOMMU
 |===
 
 [[acpi-guidance-aml]]


### PR DESCRIPTION
When the system has IOMMU, RIMT table is required. Add it to additional tables required.

RIMT spec will be maintained by RVI (https://github.com/riscv-non-isa/riscv-acpi-rimt) and is planned to be ratified by end of 2024.