### PR TITLE
Fix https://github.com/riscv-non-isa/riscv-brs/issues/168

### DIFF
--- a/smbios.adoc
+++ b/smbios.adoc
@@ -44,7 +44,7 @@ A processor is a grouping of harts in a physical package. In modern designs this
 For RISC-V class CPUs, the `Processor ID` field contains two `DWORD`-formatted values describing
 the overall physical processor package vendor and version. For some implementations
 this may also be known as the SoC ID. The first `DWORD` (offsets 08h-0Bh) is the JEP-106 code for
-the vendor. The second `DWORD` (offsets 0Ch-0Fh) reflects vendor-specific part versioning.
+the vendor, where bits 6:0 is the ID without the parity and bits 31:7 represent the number of continuation codes. The second `DWORD` (offsets 0Ch-0Fh) reflects vendor-specific part versioning.
 
 For hart-specific vendor and revision information, please see Type 44 Processor-Specific Data structures.
 


### PR DESCRIPTION
Describes the scheme by which JEP-106 codes are compressed to fit within a 32-bit value.