### PR TITLE
Add missing RVI documentation template files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+# RISC-V Code of Conduct
+All RISC-V International projects are governed by the RISC-V Code of Conduct found at https://riscv.org/community/community-code-of-conduct/.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contribution Guidelines
+
+As an open-source project, we appreciate and encourage community members to submit patches directly to the project. To maintain a well-organized development environment, we have established standards and methods for submitting changes. This document outlines the process for submitting patches to the project, ensuring that your contribution is swiftly incorporated into the codebase.
+
+# Licensing
+
+Licensing is crucial for open-source projects, as it guarantees that the software remains available under the conditions specified by the author.
+
+This project employs the Creative Commons Attribution 4.0 International license, which can be found in the LICENSE file within the project's repository.
+
+Licensing defines the rights granted to you as an author by the copyright holder. It is essential for contributors to fully understand and accept these licensing rights. In some cases, the copyright holder may not be the contributor, such as when the contributor is working on behalf of a company.
+
+# Developer Certificate of Origin (DCO)
+To uphold licensing criteria and demonstrate good faith, this project mandates adherence to the Developer Certificate of Origin (DCO) process.
+
+The DCO is an attestation appended to every contribution from each author. In the commit message of the contribution (explained in greater detail later in this document), the author adds a Signed-off-by statement, thereby accepting the DCO.
+
+When an author submits a patch, they affirm that they possess the right to submit the patch under the designated license. The DCO agreement is displayed below and at https://developercertificate.org.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b), or (c), and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+# DCO Sign-Off Methods
+The DCO necessitates the inclusion of a sign-off message in the following format for each commit within the pull request:
+```
+Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>
+```
+Please use your real name in the sign-off message.
+
+You can manually add the DCO text to your commit body or include either -s or --signoff in your standard Git commit commands. If you forget to incorporate the sign-off, you can also amend a previous commit with the sign-off by executing git commit --amend -s. If you have already pushed your changes to GitHub, you will need to force push your branch afterward using git push -f.
+
+Note:
+
+Ensure that the name and email address associated with your GitHub account match the name and email address in the Signed-off-by line of your commit message.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,6 @@
+# Governance
+This project for the template specification is governed by the Boot and Runtime Services (BRS) SIG.
+
+The group can be joined by RISC-V members at: https://lists.riscv.org/g/tech-brs.
+
+Mailing list archives are available at: https://lists.riscv.org/g/tech-brs/topics.

--- a/LICENSE
+++ b/LICENSE
@@ -49,7 +49,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
@@ -393,4 +393,3 @@ the avoidance of doubt, this paragraph does not form part of the
 public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
-

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,7 @@
+# Maintainers
+This project is maintained by the following people:
+
+- Aaron Durbin ([adurbin-rivos](https://github.com/adurbin-rivos))
+- Andrei Warkentin ([andreiw](https://github.com/andreiw))
+- Anup Patel ([avpatel](https://github.com/avpatel))
+- Sunil V L ([vlsunil](https://github.com/vlsunil))


### PR DESCRIPTION
The repo is missing a few standard files which provide information about how to contribute, who are the maintainers, code of conduct and the TG which governs this spec etc. Add those files.