### PR TITLE
Minor updates before freeze

### DIFF
--- a/acpi-id.adoc
+++ b/acpi-id.adoc
@@ -29,5 +29,7 @@ ACPI ID for any new device.
 | `RSCV0002`     | RISC-V Advanced Platform-Level Interrupt Controller (APLIC)
 | `RSCV0003`     | NS16550 UART compatible with an SPCR definition using `Interface Type` 0x12
 | `RSCV0004`     | RISC-V IOMMU implemented as a platform device
+| `RSCV0005`     | RISC-V SBI Message Proxy (MPXY) Mailbox Controller
+| `RSCV0006`     | RISC-V RPMI System MSI Interrupt Controller
 2+| _Also see <<acpi-props-uart>>._
 |===

--- a/acpi.adoc
+++ b/acpi.adoc
@@ -35,10 +35,6 @@ available to an OS loader via the standard `UEFI EFI_GRAPHICS_OUTPUT_PROTOCOL` i
  ** Use `Interface Type` 0x12 (16550-compatible with parameters defined in Generic Address Structure).
  ** There MUST be a matching AML device object with `_HID` (Hardware ID) or `_CID` (Compatible ID) `RSCV0003`.
 2+| _See <<acpi-guidance-spcr, additional guidance>>_.
-| [[acpi-namespace-dev]]`ACPI_080` | PLIC/APLIC namespace devices MUST
-be present in the ACPI namespace whenever corresponding MADT entries are
-present. <<acpi-ids, See RVI ACPI IDs>>.
-2+| _Also see <<acpi-irq-gsb, AML_090>> and <<acpi-guidance-gsi-namespace, additional guidance>>_.
 |===
 
 [[acpi-aml]]
@@ -77,6 +73,10 @@ through the driver-backed `OperationRegion`._
 the Global System Interrupt Base (`_GSB`, cite:[ACPI] Section 6.2.7) object.
 <<acpi-guidance-gsi-namespace, See additional guidance>>.
 | `AML_100` | UART device objects with ID `RSCV0003` MUST implement <<acpi-props-uart, Properties for UART Devices>>.
+| [[acpi-namespace-dev]]`AML_110` | PLIC/APLIC namespace devices MUST
+be present in the ACPI namespace whenever corresponding MADT entries are
+present. <<acpi-ids, See RVI ACPI IDs>>.
+2+| _Also see <<acpi-irq-gsb, AML_090>> and <<acpi-guidance-gsi-namespace, additional guidance>>_.
 |===
 
 include::acpi-id.adoc[]

--- a/brs.bib
+++ b/brs.bib
@@ -96,3 +96,7 @@
   url = {https://lists.riscv.org/g/sig-perf-analysis},
   year = {2024}
 }
+@electronic{RPMI,
+  title = {RISC-V Platform Management Interface Specification},
+  url = {https://github.com/riscv-non-isa/riscv-rpmi}
+}

--- a/header.adoc
+++ b/header.adoc
@@ -2,8 +2,8 @@
 :description: RISC-V Boot and Runtime Services Specification Document (BRS)
 :company: RISC-V.org
 :url-riscv: http://riscv.org
-:revdate: 6th December 2024
-:revnumber: 0.0.4
+:revdate: 6th February 2025
+:revnumber: 0.8
 :revremark: This document is Stable.
 :doctype: book
 :preface-title: Preamble

--- a/intro.adoc
+++ b/intro.adoc
@@ -55,11 +55,12 @@ Most terminology has the standard RISC-V meaning. This table captures other term
 | BRS             | _RISC-V Boot and Runtime Services Specification_. This document.
 | BRS-I           | Boot and Runtime Services recipe targeting interoperation across different software suppliers.
 | BRS-B           | Boot and Runtime Services recipe using a bespoke solution.
-| DT              | DeviceTree cite:[DT].
+| DT              | _Device Tree_ cite:[DT].
 | EBBR            | _Embedded Base Boot Requirements Specification_ cite:[EBBR].
 | OSV             | Operating System Vendor.
 | OS              | Operating System or Hypervisor.
-| Profile         | RISC-V Profile cite:[Profile].
+| Profile         | _RISC-V Profile_ cite:[Profile].
+| RPMI            | _RISC-V Platform Management Interface_ cite:[RPMI].
 | RVI             | RISC-V International.
 | SBI             | _RISC-V Supervisor Binary Interface Specification_ cite:[SBI].
 | SMBIOS          | _System Management BIOS (SMBIOS) Reference Specification_ cite:[SMBIOS].

--- a/uefi.adoc
+++ b/uefi.adoc
@@ -35,20 +35,6 @@ hand-off info to an OS, for example, to provide RAM disk information
 (e.g. via `/chosen/linux,initrd-start`)._
 |===
 
-=== BRS-I Security Requirements
-
-[width=100%]
-[%header, cols="5,25"]
-|===
-| ID#     ^| Rule
-| `USEC_010` | Systems implementing UEFI secure boot are RECOMMENDED to implement the `EFI_SECURITY_ARCH_PROTOCOL` and `EFI_SECURITY2_ARCH_PROTOCOL` protocols cite:[UEFI-PI].
-2+| _The Security and Security2 architectural protocols are overridden by some bootloaders (e.g. systemd-boot) to validate EFI binaries that cannot be validated against the UEFI security database._
-| `USEC_020` | Systems implementing a TPM MUST implement the _TCG
-EFI Protocol Specification_ cite:[TcgEfiPlat].
-|===
-
-See additional <<uefi-rt, requirements for UEFI runtime services>>.
-
 === BRS-I I/O-specific Requirements
 
 [width=100%]
@@ -84,13 +70,24 @@ See additional <<uefi-rt, requirements for UEFI runtime services>>.
 2+| _This rule is included in this specification to address a common mistake in implementing the UEFI requirements for non-volatile variables, even though it may appear redundant with the existing UEFI specification._
 | `URT_050` | UEFI runtime services MUST be able to update the UEFI variables directly without the aid of an OS.
 2+| _UEFI variables are normally saved in a dedicated storage which is not directly accessible by the operating system._
-| `URT_060` a| The following requirements MUST be met for systems with UEFI secure boot:
-
-             * MUST support a minimum of 128 KiB of non-volatile storage for UEFI variables.
-             * The maximum supported variable size MUST be at least 64 KiB.
-             * The `db` signature database variable (`EFI_IMAGE_SECURITY_DATABASE`) MUST be created with `EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS`, to prevent rollback attacks.
-             * The `dbx` signature database variable (`EFI_IMAGE_SECURITY_DATABASE1`) MUST be created with `EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS`, to prevent rollback attacks.
 |===
+
+=== BRS-I Security Requirements
+
+[width=100%]
+[%header, cols="5,25"]
+|===
+| ID#     ^| Rule
+| `USEC_010` | Systems implementing UEFI secure boot are RECOMMENDED to implement the `EFI_SECURITY_ARCH_PROTOCOL` and `EFI_SECURITY2_ARCH_PROTOCOL` protocols cite:[UEFI-PI].
+2+| _The Security and Security2 architectural protocols are overridden by some bootloaders (e.g. systemd-boot) to validate EFI binaries that cannot be validated against the UEFI security database._
+| `USEC_020` | Systems implementing a TPM MUST implement the _TCG EFI Protocol Specification_ cite:[TcgEfiPlat].
+| `USEC_030` | Systems with UEFI secure boot MUST support a minimum of 128 KiB of non-volatile storage for UEFI variables.
+| `USEC_040` | For systems with UEFI secure boot, the maximum supported variable size MUST be at least 64 KiB.
+| `USEC_050` | For systems with UEFI secure boot, the `db` signature database variable (`EFI_IMAGE_SECURITY_DATABASE`) MUST be created with `EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS`, to prevent rollback attacks.
+| `USEC_060` | For systems with UEFI secure boot, the `dbx` signature database variable (`EFI_IMAGE_SECURITY_DATABASE1`) MUST be created with `EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS`, to prevent rollback attacks.
+|===
+
+See additional <<uefi-rt, requirements for UEFI runtime services>>.
 
 === BRS-I Firmware Update
 


### PR DESCRIPTION
1) Reserve ACPI IDs for RPMI/MPXY based system MSI controller and mailbox. Not functional / requirement changed.
2) Move ACPI_080 under AML requirements. No change in requirements, just reorg.
3) Move URT_060 under security requirements.
4) Update the version as per new RVI versioning scheme.