### PR TITLE
Fix changed requirement number

### DIFF
--- a/brs_tests.adoc
+++ b/brs_tests.adoc
@@ -83,6 +83,10 @@
 | ID#            ^| Algorithm
 | `OE_USEC_010_010` | _FIXME_.
 | `OE_USEC_020_010` | _FIXME_.
+| `OE_USEC_030_010` | _FIXME_.
+| `OE_USEC_040_010` | _FIXME_.
+| `OE_USEC_050_010` | _FIXME_.
+| `OE_USEC_060_010` | _FIXME_.
 |===
 
 <<<
@@ -110,7 +114,6 @@
 | `ME_URT_030_010` | _FIXME_.
 | `ME_URT_040_010` | _FIXME_.
 | `ME_URT_050_010` | _FIXME_.
-| `OE_URT_060_010` | _FIXME_.
 |===
 
 <<<
@@ -141,7 +144,6 @@
 | `OE_ACPI_040_010` | _FIXME_.
 | `OE_ACPI_050_010` | _FIXME_.
 | `OE_ACPI_060_010` | _FIXME_.
-| `OE_ACPI_080_010` | _FIXME_.
 |===
 
 <<<
@@ -162,6 +164,7 @@
 | `OE_AML_080_010` | _FIXME_.
 | `ME_AML_090_010` | _FIXME_.
 | `ME_AML_100_010` | _FIXME_.
+| `ME_AML_110_010` | _FIXME_.
 |===
 
 <<<

--- a/brs_ts_header.adoc
+++ b/brs_ts_header.adoc
@@ -2,9 +2,9 @@
 :description: RISC-V Boot and Runtime Services Test Specification
 :company: RISC-V.org
 :url-riscv: http://riscv.org
-:revdate: 6th December 2024
-:revnumber: 0.0.4
-:revremark: This document is Stable.
+:revdate: 7th February 2024
+:revnumber: 0.1
+:revremark: This document is in Development state.  Change should be expected.
 :doctype: book
 :preface-title: Preamble
 :colophon:
@@ -39,7 +39,7 @@ BRS Task Group
 
 // Preamble
 [WARNING]
-.This document is in the link:http://riscv.org/spec-state[Development state]
+.This document is in the link:https://lf-riscv.atlassian.net/wiki/display/HOME/Specification+States[Development state]
 ====
 Assume everything can change. This draft specification will change before
 being accepted as standard, so implementations made to this draft

--- a/header.adoc
+++ b/header.adoc
@@ -2,7 +2,7 @@
 :description: RISC-V Boot and Runtime Services Specification Document (BRS)
 :company: RISC-V.org
 :url-riscv: http://riscv.org
-:revdate: 6th February 2025
+:revdate: 7th February 2025
 :revnumber: 0.8
 :revremark: This document is Stable.
 :doctype: book
@@ -39,11 +39,9 @@ BRS Task Group
 
 // Preamble
 [WARNING]
-.This document is in the link:http://riscv.org/spec-state[Development state]
+.This document is in the link:https://lf-riscv.atlassian.net/wiki/display/HOME/Specification+States[Stable state]
 ====
-Assume everything can change. This draft specification will change before 
-being accepted as standard, so systems made to this draft 
-specification will likely not conform to the future standard.
+Assume anything could still change, but limited change should be expected.
 ====
 
 [preface]

--- a/non-normative/acpi.adoc
+++ b/non-normative/acpi.adoc
@@ -108,7 +108,7 @@ describe affinities.
 [[acpi-guidance-gsi-namespace]]
 ==== PLIC/APLIC Namespace Devices
 
-Here's an example of an ASL excerpt satisfying <<acpi-namespace-dev, `ACPI_080`>>
+Here's an example of an ASL excerpt satisfying <<acpi-namespace-dev, `AML_110`>>
 and <<acpi-irq-gsb, `AML_090`>> requirements.
 
  Scope (\_SB)


### PR DESCRIPTION
BRS Test spec and non-normative text still referred to old requirement numbers which are moved into different section. Fix them.