### PR TITLE
Strengthen requirements on the SBI implementation

### DIFF
--- a/brs_tests.adoc
+++ b/brs_tests.adoc
@@ -39,6 +39,11 @@
                      . Verify that the result is true.
 | `ME_SBI_060_010` | . Probe the presence of PMU extension by sbi_probe_extension().
                      . Verify that the result is true.
+| `OE_SBI_070_010` | . If ACPI is used and the ACPI SPCR table references Interface Type 0x15
+                     .. Probe the presence of DBCN extension by sbi_probe_extension().
+                     .. Verify that the result is true.
+                     . Else
+                     .. Report DBCN is not mandatory in this configuration and skip the test.
 |===
 
 <<<

--- a/brs_tests.adoc
+++ b/brs_tests.adoc
@@ -31,28 +31,14 @@
 | `ME_SBI_020_010` | . See `ME_SBI_010_010`.
                      . Probe the presence of HSM extension by sbi_probe_extension().
                      . Verify that the result is true.
-| `OE_SBI_030_010` | . If Sstc extension was present(See `ME_HR_010_010`)
-                     .. Report Sstc was present and Skip the test.
-                     . Else
-                     .. Probe the presence of TIME extension by sbi_probe_extension().
-                     .. Verify that the result is true.
-| `OE_SBI_040_010` | . If Ssaia extension was present(See `ME_HR_010_010`)
-                     .. Report Ssaia was present and Skip the test.
-                     . Else
-                     .. Probe the presence of sPI extension by sbi_probe_extension().
-                     .. Verify that the result is true.
-| `OE_SBI_050_010` | . If Ssaia extension was present(See `ME_HR_010_010`)
-                     .. Report Ssaia was present and Skip the test.
-                     . Else
-                     .. Probe the presence of RFNC extension by sbi_probe_extension().
-                     .. Verify that the result is true.
-| `OE_SBI_060_010` | . If Smcsrind,Sscsrind,Smcdeleg,Ssccfg extensions
-                       were present(See `ME_HR_010_010`).
-                     .. Report Smcsrind,Sscsrind,Smcdeleg,Ssccfg  was present and
-                        Skip the test.
-                     . Else
-                     .. Probe the presence of PMU extension by sbi_probe_extension().
-                     .. Verify that the result is true.
+| `ME_SBI_030_010` | . Probe the presence of TIME extension by sbi_probe_extension().
+                     . Verify that the result is true.
+| `ME_SBI_040_010` | . Probe the presence of sPI extension by sbi_probe_extension().
+                     . Verify that the result is true.
+| `ME_SBI_050_010` | . Probe the presence of RFNC extension by sbi_probe_extension().
+                     . Verify that the result is true.
+| `ME_SBI_060_010` | . Probe the presence of PMU extension by sbi_probe_extension().
+                     . Verify that the result is true.
 |===
 
 <<<

--- a/sbi.adoc
+++ b/sbi.adoc
@@ -25,4 +25,5 @@ Certain requirements are conditional on the presence of RISC-V ISA extensions or
 | `SBI_040`  | The S-Mode IPI Extension (sPI) MUST be implemented.
 | `SBI_050`  | The RFENCE Extension (RFNC) extension MUST be implemented.
 | `SBI_060`  | The Performance Monitoring Extension (PMU) MUST be implemented.
+| `SBI_070`  | The Debug Console Extension (DBCN) MUST be implemented if the ACPI SPCR table references Interface Type 0x15.
 |===

--- a/sbi.adoc
+++ b/sbi.adoc
@@ -21,8 +21,8 @@ Certain requirements are conditional on the presence of RISC-V ISA extensions or
 [%header, cols="5,25"]
 |===
 | ID#     ^| Rule
-| `SBI_030`  | The Timer Extension (TIME) MUST be implemented, if the RISC-V "stimecmp / vstimecmp" Extension (Sstc, cite:[Sstc]) is not available.
-| `SBI_040`  | The S-Mode IPI Extension (sPI) MUST be implemented, if the Incoming MSI Controller (IMSIC, cite:[Aia]) is not available.
-| `SBI_050`  | The RFENCE Extension (RFNC) extension MUST be implemented, if the Incoming MSI Controller (IMSIC, cite:[Aia]) is not available.
-| `SBI_060`  | The Performance Monitoring Extension (PMU) MUST be implemented, if the counter delegation-related S-Mode ISA extensions (Sscsrind cite:[Sscsrind] and Ssccfg cite:[Smcdeleg]) are not present.
+| `SBI_030`  | The Timer Extension (TIME) MUST be implemented.
+| `SBI_040`  | The S-Mode IPI Extension (sPI) MUST be implemented.
+| `SBI_050`  | The RFENCE Extension (RFNC) extension MUST be implemented.
+| `SBI_060`  | The Performance Monitoring Extension (PMU) MUST be implemented.
 |===


### PR DESCRIPTION
When doing a round of review over the BRS specification, we noticed that a few of the SBI requirements seem likely to cause compatibility issues between operating systems and future BRS compliant SBI implementations. We describe our concerns below, and propose mitigations as implemented in this pull request.

## Compatibility problems due to non-mandatory SBI extensions

Requirements SBI_030 through SBI_060 allow the SBI implementation to omit an SBI extension (TIME, IPI, RFENCE, or PMU) if certain hardware functionality is available to S-mode.

We believe this places an unreasonable implicit requirement on operating system software to include multiple implementations of the corresponding functionality: one using the SBI extension, and one using the hardware directly. There are several reasons for this:

1) No existing operating system is compatible with this requirement. For example, Linux does not currently support the Ssccfg (PMU counter delegation) extension. Even if it did, it would not be appropriate to limit BRS compatibility to just Linux. We create a situation where today's OSes work on today's BRS compliant firmware, but may stop working after upgrading to newer BRS compliant hardware/firmware due to the SBI extension being removed.

2) The SBI extensions can add useful functionality beyond what the corresponding hardware provides. For example, the SBI RFENCE extension allows platforms to optimize broadcast fences using custom instructions, which is not something possible with AIA. Similarly, the SBI RFENCE extension can have lower latency because it does not require the target harts to have interrupts enabled at S-mode. Due to these reasons, operating systems may want to use the SBI extension unconditionally.

3) Similarly, the presence of the given hardware extension (e.g. AIA) does not guarantee that the operating system can use it for the purpose assumed by the BRS requirement. For example, the platform may not have enough free IMSIC interrupt identities to use them to implement IPIs.

## Mandating SBI DBCN extension support when referenced by the ACPI SPCR table

To simplify boot and operating system code, we recommend that SBI DBCN support be made mandatory if the debug console is specified in the SPCR table.