### PR TITLE
Require the SBI DBCN extension if referenced by the ACPI SPCR table

### DIFF
--- a/brs_tests.adoc
+++ b/brs_tests.adoc
@@ -53,6 +53,11 @@
                      . Else
                      .. Probe the presence of PMU extension by sbi_probe_extension().
                      .. Verify that the result is true.
+| `OE_SBI_070_010` | . If ACPI is used and the ACPI SPCR table references Interface Type 0x15
+                     .. Probe the presence of DBCN extension by sbi_probe_extension().
+                     .. Verify that the result is true.
+                     . Else
+                     .. Report DBCN is not mandatory in this configuration and skip the test.
 |===
 
 <<<

--- a/sbi.adoc
+++ b/sbi.adoc
@@ -25,4 +25,5 @@ Certain requirements are conditional on the presence of RISC-V ISA extensions or
 | `SBI_040`  | The S-Mode IPI Extension (sPI) MUST be implemented, if the Incoming MSI Controller (IMSIC, cite:[Aia]) is not available.
 | `SBI_050`  | The RFENCE Extension (RFNC) extension MUST be implemented, if the Incoming MSI Controller (IMSIC, cite:[Aia]) is not available.
 | `SBI_060`  | The Performance Monitoring Extension (PMU) MUST be implemented, if the counter delegation-related S-Mode ISA extensions (Sscsrind cite:[Sscsrind] and Ssccfg cite:[Smcdeleg]) are not present.
+| `SBI_070`  | The Debug Console Extension (DBCN) MUST be implemented if the ACPI SPCR table references Interface Type 0x15.
 |===


### PR DESCRIPTION
This ensures that the ACPI tables are in sync with the SBI firmware.